### PR TITLE
Remove `polyfills.ts` from TypeScript config on `starter` branch

### DIFF
--- a/projects/mfe1/tsconfig.app.json
+++ b/projects/mfe1/tsconfig.app.json
@@ -6,8 +6,7 @@
     "types": []
   },
   "files": [
-    "src/main.ts",
-    "src/polyfills.ts"
+    "src/main.ts"
   ],
   "include": [
     "src/**/*.d.ts"

--- a/projects/mfe1/tsconfig.spec.json
+++ b/projects/mfe1/tsconfig.spec.json
@@ -8,8 +8,7 @@
     ]
   },
   "files": [
-    "src/test.ts",
-    "src/polyfills.ts"
+    "src/test.ts"
   ],
   "include": [
     "src/**/*.spec.ts",

--- a/projects/shell/tsconfig.app.json
+++ b/projects/shell/tsconfig.app.json
@@ -6,8 +6,7 @@
     "types": []
   },
   "files": [
-    "src/main.ts",
-    "src/polyfills.ts"
+    "src/main.ts"
   ],
   "include": [
     "src/**/*.d.ts"

--- a/projects/shell/tsconfig.spec.json
+++ b/projects/shell/tsconfig.spec.json
@@ -8,8 +8,7 @@
     ]
   },
   "files": [
-    "src/test.ts",
-    "src/polyfills.ts"
+    "src/test.ts"
   ],
   "include": [
     "src/**/*.spec.ts",


### PR DESCRIPTION
This file was removed in 10e35d4deb6e792100a19c1359845e55d7f5dcbf, which broke the build.